### PR TITLE
test installation on mac os

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+pyvenv.cfg
+bin

--- a/README.md
+++ b/README.md
@@ -1,88 +1,132 @@
-# datenocmd
-Command-line tool to use with Dateno dataset search engine
+# DatenoCmd
 
+Welcome to the DatenoCmd repository! This repository contains a command-line interface (CLI) tool designed to work seamlessly with the Dateno dataset search engine.
 
-## Getting started
+## Getting Started
 
-1. Install tool with command ```python3 setup.py install``` or ```python3 -m build .```
-2. Obtain your Dateno API key at 'https://dateno.io'. Sign in and copy copy your key somethere locally
-2. Create YAML config file .dateno.yaml in you working or user directory. Add line: "apikey: your_secret_key". 
+Follow these steps to get started with our tool:
 
-# Commands
+1. **Clone the Repository and Set Up the Environment**
 
-## Dataset search
+    First, clone the repository and set up your environment. You can use `venv`, `conda`, or any other virtual environment manager of your choice.
 
-Dataset search command is ```dateno index search``` it require *query* argument and several parameters could be added to format output and refine search results.
+    ```sh
+    git clone git@github.com:datenoio/datenocmd.git
+    # Activate your virtual environment
+    pip install -r requirements.txt
+    python3 setup.py install # or python3 -m build .
+    ```
 
-    # Search keywords "Atlantic salmon" and return table with id, dataset title, source name and source uid. Debug enabled
-    $ dateno index search 'Atlantic salmon' --headers id,dataset.title,source.name,source.uid --debug --mode results --output Atlantic_salmon.csv --limit 5
+2. **Obtain Your Dateno API Key**
 
-    # Search keywords "budget" and only in English and only for country Kyrgyzstan and return table with id, dataset title, source name and source uid. Debug enabled
-    $ dateno index search 'budget' --filters "source.langs.name"="English";"source.countries.name"="Kyrgyzstan" --headers id,dataset.title,source.name,source.uid --debug --mode results --limit 5
+    Visit [Dateno.io](https://dateno.io) to sign in and obtain your API key. Copy the key and store it securely on your local machine.
 
-    # Return total number of available datasets for keyword "budget" and country Kyrgyzstan
-    $ dateno index search 'budget' --filters "source.countries.name"="Kyrgyzstan" --mode totals --limit 5
+3. **Create a Configuration File**
 
-    # Return facets distribution for keyword "budget" and country Kyrgyzstan
-    $ dateno index search 'budget' --filters "source.countries.name"="Kyrgyzstan" --mode facets --limit 5
+    In your working or user directory, create a configuration file named `.dateno.yaml` and add your API key. You can do this with the following command:
 
-    # Search keywords "budget" and only in English and only for country Kyrgyzstan and return table with id, dataset title, source name and source uid with page 2 and 50 records
-    $ dateno index search 'budget' --filters "source.countries.name"="Kyrgyzstan" --mode facets --page 2 --per-page 50
+    ```sh
+    echo "apikey: YOUR_SECRET_KEY" >> .dateno.yaml
+    ```
 
-Note: Windows users should use single quotes with *filters* argument. Example
-```dateno index search 'budget' --filters '"source.countries.name"="Kyrgyzstan"' --mode facets``` --limit 5
+4. **Make Your First Request**
 
+    Now you're ready to make your first request using DatenoCmd.
 
-Additional parameters:
-* --headers header_fields - List of fields to be printed is 'results' mode selected. Nested fields separated by ., for example 'dataset.title'
-* --filters filters_text - Text of search filters to be applied, separated by ;. List of filters available from facets distribution
-* --debug - Add more debugging output. Warning, API key could be printed during debug
-* --format - could be 'json' or 'yaml'. JSON is original, YAML is more human readable
-* --output filename - writes results to the file instead of stdout
-* --mode mode_name - search output mode: raw, results, facets or totals
-* --page number  - set search results page number
-* --per_page number - set size of the results page
+    ```sh
+    dateno index search 'Atlantic salmon' --limit 1 
+    ```
 
+Follow the documentation below for more details on available commands and options.
 
-Supported modes: 
-* raw - raw data as is from the source
-* results - only results as table
-* facets - only facets distribution, helpful to refine search
-* totals - only estimated total results
+## Commands
 
+There are three available commands:
 
-## Fetch dataset record
+- Search for datasets
+- Fetch a single dataset, which requires a dataset ID
+- Fetch metadata of a single catalog (data source), which requires a catalog ID
 
-Returns single dataset entry with links to the all resources
+All commands share the following **common parameters**:
 
-    # Get single record and print it as YAML to stdout
-    $ dateno index get 480906e2ae159fcf99037eecc7601d44aeb3c95f2372d98f0eb514acc7a38bc7
+- `--debug`: Add more debugging output. **Warning:** API key could be printed during debug.
+- `--format`: Output format, can be `yaml` (default) or `json`. JSON is the original format, YAML is more human-readable.
+- `--output filename`: Writes results to the specified file instead of stdout.
 
-    # Get single record and print it as JSON to the record.json file
-    $ dateno index get 480906e2ae159fcf99037eecc7601d44aeb3c95f2372d98f0eb514acc7a38bc7 --format json --output record.json
+### Dataset search
 
-Parameters:
-* --debug - Add more debugging output. Warning, API key could be printed during debug
-* --format - could be 'json' or 'yaml'. JSON is original, YAML is more human readable
-* --output filename - writes results to the file instead of stdout
+The dataset search command is `dateno index search`. It requires a *query* argument and supports several parameters to format the output and refine search results.
 
+```sh
+# Search for "Atlantic salmon" and return a table with id, dataset title, source name, and source uid. Debug mode enabled.
+$ dateno index search 'Atlantic salmon' --headers id,dataset.title,source.name,source.uid --debug --mode results --output Atlantic_salmon.csv --limit 5
 
-## Fetch data catalog metadata
+# Search for "budget" in English for the country Kyrgyzstan and return a table with id, dataset title, source name, and source uid. Debug mode enabled.
+$ dateno index search 'budget' --filters "source.langs.name"="English";"source.countries.name"="Kyrgyzstan" --headers id,dataset.title,source.name,source.uid --debug --mode results --limit 5
 
-Returns single data catalog entry by uid
+# Return the total number of available datasets for the keyword "budget" in Kyrgyzstan.
+$ dateno index search 'budget' --filters "source.countries.name"="Kyrgyzstan" --mode totals --limit 5
 
-    # Get data catalog record and print it as YAML to stdout
-    $ dateno catalogs get cdi00004185
+# Return facets distribution for the keyword "budget" in Kyrgyzstan.
+$ dateno index search 'budget' --filters "source.countries.name"="Kyrgyzstan" --mode facets --limit 5
 
-    # Get data catalog record and print it as JSON to the record.json file
-    $ dateno catalogs get cdi00004185 --format json --output record.json
+# Search for "budget" in English for the country Kyrgyzstan and return a table with id, dataset title, source name, and source uid with page 2 and 50 records.
+$ dateno index search 'budget' --filters "source.countries.name"="Kyrgyzstan" --mode facets --page 2 --per-page 50
+```
 
-Parameters:
-* --debug - Add more debugging output. Warning, API key could be printed during debug
-* --format - could be 'json' or 'yaml'. JSON is original, YAML is more human readable
-* --output filename - writes results to the file instead of stdout
+> **Note:** Windows users should use single quotes with the *filters* argument. For example:
+> ```dateno index search 'budget' --filters '"source.countries.name"="Kyrgyzstan"' --mode facets --limit 5```
 
+**Additional parameters**:
 
-## Questions
+- `--mode mode_name`: Search output mode: `results` (default), `raw`, `facets`, or `totals`.
+- `--headers header_fields`: List of fields to be printed in `--mode results`. Nested fields are separated by a dot (e.g., `dataset.title`).
+- `--filters filters_text`: Text of search filters to be applied, separated by semicolons. List of filters available from facets distribution.
+- `--page number`: Set the search results page number.
+- `--per_page number`: Set the size of the results page.
 
-If you have any questions about Dateno command line tool, please add an issue to the repository [issues](https://github.com/datenoio/datenocmd/issues) or write to dateno@dateno.io
+**Supported `mode`s**:
+
+- `raw`: Raw data as is from the source.
+- `results`: Only results as a table.
+- `facets`: Only facets distribution, helpful to refine search.
+- `totals`: Only estimated total results.
+
+### Fetch dataset record
+
+Returns a single dataset entry with links to all resources.
+
+```sh
+# Get a single record and print it as YAML to stdout.
+$ dateno index get 480906e2ae159fcf99037eecc7601d44aeb3c95f2372d98f0eb514acc7a38bc7
+
+# Get a single record and print it as JSON to the record.json file.
+$ dateno index get 480906e2ae159fcf99037eecc7601d44aeb3c95f2372d98f0eb514acc7a38bc7 --format json --output record.json
+```
+
+### Fetch data catalog metadata
+
+Returns a single data catalog entry by uid.
+
+```sh
+# Get a data catalog record and print it as YAML to stdout.
+$ dateno catalogs get cdi00004185
+
+# Get a data catalog record and print it as JSON to the record.json file.
+$ dateno catalogs get cdi00004185 --format json --output record.json
+```
+
+## Support
+
+If you have any questions or encounter issues with the Dateno command-line tool, please feel free to:
+
+- Open an issue in the repository [here](https://github.com/datenoio/datenocmd/issues).
+- Reach out to us via email at <dateno@dateno.io>.
+- [Join](https://discord.com/invite/tydNfp5EY8) the Discord community
+
+## Other Dateno Resources
+
+- [Quick Start Guide](https://docs.dateno.io/docs/quick-start/)
+- [API Documentation](https://api.dateno.io/)
+- Web Search <https://dateno.io>
+- [Your Account](https://my.dateno.io)

--- a/dateno/core.py
+++ b/dateno/core.py
@@ -136,14 +136,14 @@ def index_search(query, filters:str="", offset:int=0, page:int=1, limit:int=500,
                 f.close()
         elif mode == 'totals':
             f = open(output, 'w', encoding='utf8')
-            totals = results['total']['value']# if 'totalHits' in results.keys() else results['estimatedTotalHits']
+            totals = results['hits']['total']['value']# if 'totalHits' in results.keys() else results['estimatedTotalHits']
             f.write(str(totals))
             f.close()
     else:       
        if mode == 'raw':
            print(results)
        elif mode == 'totals':
-           totals = results['total']['value']# if 'totalHits' in results.keys() else results['estimatedTotalHits']
+           totals = results['hits']['total']['value']# if 'totalHits' in results.keys() else results['estimatedTotalHits']
            print(totals)
        elif mode == 'facets':
            if format == 'json':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
+setuptools
 PyYAML
 typer
 tabulate
 flatdict
 requests
-chardet


### PR DESCRIPTION
- core.py: it fixes bug for --mode totals (`dateno index search 'test' --limit 1 --mode totals`)
- readme: getting started: the initial steps required to get started are now more thoroughly described.
- requirements.txt: added setuptools so `python setup.py` runs smoothly, removed a Python package that is not explicitly imported anywhere in the code. 